### PR TITLE
Prevent visible slide changes while tabbing through slideshow

### DIFF
--- a/js/frontend/slideshow/slideshow.animation.js
+++ b/js/frontend/slideshow/slideshow.animation.js
@@ -259,9 +259,9 @@
 			$.proxy(function()
 			{
 				// Remove current view identifier class from the previous view
-				$currentView.removeClass('slideshow_currentView');
+				$currentView.removeClass('slideshow_currentView').find('a').attr('tabindex', '-1');
 				$nextView.removeClass('slideshow_nextView');
-				$nextView.addClass('slideshow_currentView');
+				$nextView.addClass('slideshow_currentView').find('a').attr('tabindex', '0');
 
 				// Update visible views array after animating
 				this.visibleViews = [ viewID ];

--- a/js/frontend/slideshow/slideshow.constructor.js
+++ b/js/frontend/slideshow/slideshow.constructor.js
@@ -100,7 +100,7 @@
 				// Hide views, except for the one that's currently showing.
 				if (viewID != this.visibleViews[0])
 				{
-					$view.css('top', this.$container.outerHeight(true));
+					$view.css('top', this.$container.outerHeight(true)).find('a').attr('tabindex', '-1');
 				}
 				else
 				{


### PR DESCRIPTION
Tabbing through links on inactive slides could trigger changes in the currently visible slide - I think stemming from z-index issues. This removes links on inactive slides from the tab order, preventing the wrong slide from displaying during keyboard navigation.
