### PR TITLE
Use relative URLs when getting admin_url()

### DIFF
--- a/classes/SlideshowPluginSlideshowStylesheet.php
+++ b/classes/SlideshowPluginSlideshowStylesheet.php
@@ -58,7 +58,7 @@ class SlideshowPluginSlideshowStylesheet
 			{
 				wp_enqueue_style(
 					'slideshow-jquery-image-gallery-ajax-stylesheet_' . $stylesheetKey,
-					admin_url('admin-ajax.php?action=slideshow_jquery_image_gallery_load_stylesheet&style=' . $stylesheetKey),
+					admin_url('admin-ajax.php?action=slideshow_jquery_image_gallery_load_stylesheet&style=' . $stylesheetKey, 'relative'),
 					array(),
 					$stylesheetValue['version']
 				);
@@ -116,7 +116,7 @@ class SlideshowPluginSlideshowStylesheet
 		{
 			wp_enqueue_style(
 				'slideshow-jquery-image-gallery-ajax-stylesheet_' . $name,
-				admin_url('admin-ajax.php?action=slideshow_jquery_image_gallery_load_stylesheet&style=' . $name),
+				admin_url('admin-ajax.php?action=slideshow_jquery_image_gallery_load_stylesheet&style=' . $name, 'relative'),
 				array(),
 				$version
 			);


### PR DESCRIPTION
This fixes an issue when using FORCE_SSL_LOGIN and/or FORCE_SSL_ADMIN where the URL on the frontend to call admin-ajax.php uses HTTPS when the frontend of the site uses HTTP.
