### PR TITLE
Always chooses the first slideshow in the select.

### DIFF
--- a/js/backend/shortcode.js
+++ b/js/backend/shortcode.js
@@ -16,11 +16,11 @@ slideshow_jquery_image_gallery_backend_script.shortcode = function()
 	 */
 	self.activateShortcodeInserter = function()
 	{
-		$('.insertSlideshowShortcodeSlideshowInsertButton').click(function()
+		$('.insertSlideshowShortcodeSlideshowInsertButton').click(function(event)
 		{
 			var undefinedSlideshowMessage = 'No slideshow selected.',
 				shortcode                 = 'slideshow_deploy',
-				slideshowID               = parseInt($('#insertSlideshowShortcodeSlideshowSelect').val(), 10),
+				slideshowID               = parseInt($(event.target).closest('table').find('select').val(), 10),
 				extraData                 = window.slideshow_jquery_image_gallery_backend_script_shortcode;
 
 			if (typeof extraData === 'object')


### PR DESCRIPTION
This plugin is incompatible with [ACF](http://www.advancedcustomfields.com/).

When adding a upload field ACF outputs a hidden dummy editor at the bottom of the edit page for a post (I do not know why). 

The line [here](https://github.com/Boonstra/Slideshow/blob/master/js/backend/shortcode.js#L23) looks for an element with ID `insertSlideshowShortcodeSlideshowSelect`. But because ACF outputs the dummy editor we end up with two elements with the same ID. The modal (a.k.a. ThickBox) always ends up at the end of the document, meaning that the code always selects the value of the select box in the dummy editor. I hope you can follow :)

Changing the line to something more contextual like: 
`slideshowID = parseInt($(event.target).closest('table').find('select').val(), 10),` would make this plugin work again properly. This guards against any duplicates created by other plugins and assures that the modal will always use the value of the select next to the insert-button.